### PR TITLE
Sticky footer

### DIFF
--- a/assets/scss/stylesheet.css
+++ b/assets/scss/stylesheet.css
@@ -92,8 +92,16 @@ main.main {
   height: 100%;
   overflow-y: scroll;
   transform: translateY(0%);
+}
+
+.scroll__container > section {
   background-color: var(--base-black);
 }
+
+.scroll__container > *:nth-last-child(2) {
+  border-bottom: 0.75px solid var(--base-white);
+}
+
 
 section {
   position: relative;
@@ -111,6 +119,11 @@ section.footer-gap {
 section.footer-block {
   height: 93.6vh;
   overflow: hidden;
+  position: sticky;
+  transform: translateZ(0);
+  bottom: 0;
+  left: 0;
+  z-index: -100;
 }
 
 img#parallaxitem {
@@ -1102,7 +1115,7 @@ article.active {
 .grid {
   padding-left: var(--padding);
   padding-right: var(--padding);
-  margin-bottom: var(--quad-space);
+  padding-bottom: var(--quad-space);
   display: grid;
   grid-gap: var(--gutter);
   grid-template-columns: 1fr 1fr;
@@ -2056,8 +2069,8 @@ ul.grid-recent-work {
   grid-gap: var(--gutter);
   grid-template-columns: 1fr 1fr;
   padding-top: var(--tripple-space);
-  margin-bottom: var(--tripple-space);
-  margin-bottom: var(--quad-space);
+  padding-bottom: var(--tripple-space);
+  padding-bottom: var(--quad-space);
 }
 
 div.recent-work-end-line {
@@ -2104,7 +2117,6 @@ div.insight_wrapper:hover .read_more_wrapper {
   grid-template-columns: 1fr 1fr 1fr 1fr;
   padding-top: 35vh;
   padding-bottom: var(--quad-space);
-  margin-top: var(--padding);
 }
 
 figcaption.insight-date {

--- a/assets/scss/stylesheet.css
+++ b/assets/scss/stylesheet.css
@@ -263,7 +263,7 @@ span.project-initals {
     padding-top: var(--padding);
   }
   section.footer-block {
-    height: 91vh;
+    height: 80vh;
     overflow: hidden;
   }
 }
@@ -2175,7 +2175,7 @@ div.insight_author {
     grid-gap: var(--gutter);
     grid-template-columns: 1fr 1fr;
     padding-top: 0vh;
-    margin-top: 30vh;
+    padding-top: 30vh;
     border-bottom: 0px solid var(--base-white);
     padding-bottom: var(--mobile-pent-space);
   }

--- a/site/snippets/approachandprocess.php
+++ b/site/snippets/approachandprocess.php
@@ -1,9 +1,9 @@
-
 <?php $approachprocesstab = $page->children()->listed()->paginate(1) ?>
-<?php foreach ($approachprocesstab as $approachprocess): ?>
-  <figcaption class="img-caption insight-date">
-    <p><?= $approachprocess->title() ?></p>
-  </figcaption>
+<section>
+  <?php foreach ($approachprocesstab as $approachprocess): ?>
+    <figcaption class="img-caption insight-date">
+      <p><?= $approachprocess->title() ?></p>
+    </figcaption>
     <div class="paragraph-one-wrapper-approachprocess approach">
       <?php if ($page->isMobile()): ?>
       <?php else: ?>
@@ -11,7 +11,7 @@
         </span>
       <?php endif ?>
       <h3 class="main-paragraph"><?= $approachprocess->paragraphone()->html() ?></h3>
-    </div> 
+    </div>
     <div class="title-paragraph-wrapper-approachprocess approach">
       <span>
         <h2><?= $approachprocess->approachprocessinitaltitle()->html() ?></h2>
@@ -19,81 +19,78 @@
     </div>
     <?php $approaches = $approachprocess->children()->listed() ?>
     <?php foreach ($approaches as $approach): ?>
-        <div class="title-paragraph-wrapper-approach approach">
-          <span class="approach-title">
-            <h3 id="approachTitle" class="approach_titles"><?= $approach->number()->html() ?></h3>
-            <h3 class="approach_titles subheading"><?= $approach->title()->html() ?></h3>
-          </span>
-          <span class="approach-paragraph">
-            <h3 id="approachParagraph" class="subtitle_two"><?= $approach->paragraph()->html() ?></h3>
-          </span> 
-        </div>
+      <div class="title-paragraph-wrapper-approach approach">
+        <span class="approach-title">
+          <h3 id="approachTitle" class="approach_titles"><?= $approach->number()->html() ?></h3>
+          <h3 class="approach_titles subheading"><?= $approach->title()->html() ?></h3>
+        </span>
+        <span class="approach-paragraph">
+          <h3 id="approachParagraph" class="subtitle_two"><?= $approach->paragraph()->html() ?></h3>
+        </span>
+      </div>
     <?php endforeach; ?>
-<?php endforeach; ?>
+  <?php endforeach; ?>
+</section>
 
 <script>
   <?php if ($page->isMobile()): ?>
     const approachWrappers = document.querySelectorAll(".title-paragraph-wrapper-approach");
-      const observer = new IntersectionObserver(entries => {
-          entries.forEach(entry => {
-              entry.target.classList.toggle("show", entry.isIntersecting);
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        entry.target.classList.toggle("show", entry.isIntersecting);
 
-              const currentTitles = entry.target.querySelectorAll(".approach-title #approachTitle");
-              currentTitles.forEach(title => {
-                title.classList.toggle("title-showing", entry.isIntersecting);
-              })
+        const currentTitles = entry.target.querySelectorAll(".approach-title #approachTitle");
+        currentTitles.forEach(title => {
+          title.classList.toggle("title-showing", entry.isIntersecting);
+        })
 
-              const currentTitles2 = entry.target.querySelectorAll(".approach-title .subheading");
-              currentTitles2.forEach(title2 => {
-                title2.classList.toggle("title-showing", entry.isIntersecting);
-              })
-      
-              const currentParagraph = entry.target.querySelector(".approach-paragraph");
-              currentParagraph.classList.toggle("paragraph-showing", entry.isIntersecting);
-          })
-      },
-      {
-        rootMargin:'-50%',
-        // threshold: 0.9,
-      }
-    )
+        const currentTitles2 = entry.target.querySelectorAll(".approach-title .subheading");
+        currentTitles2.forEach(title2 => {
+          title2.classList.toggle("title-showing", entry.isIntersecting);
+        })
+
+        const currentParagraph = entry.target.querySelector(".approach-paragraph");
+        currentParagraph.classList.toggle("paragraph-showing", entry.isIntersecting);
+      })
+    }, {
+      rootMargin: '-50%',
+      // threshold: 0.9,
+    })
     approachWrappers.forEach(approach => {
-        observer.observe(approach)
+      observer.observe(approach)
     })
 
     var approaches = document.querySelectorAll('.title-paragraph-wrapper-approach');
-    var last = approaches[approaches.length- 1];
+    var last = approaches[approaches.length - 1];
     last.style.paddingBottom = "5rem";
   <?php else: ?>
     const approachWrappers = document.querySelectorAll(".title-paragraph-wrapper-approach");
-      const observer = new IntersectionObserver(entries => {
-          entries.forEach(entry => {
-              entry.target.classList.toggle("show", entry.isIntersecting);
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        entry.target.classList.toggle("show", entry.isIntersecting);
 
-              const currentTitles = entry.target.querySelectorAll(".approach-title #approachTitle");
-              currentTitles.forEach(title => {
-                title.classList.toggle("title-showing", entry.isIntersecting);
-              })
+        const currentTitles = entry.target.querySelectorAll(".approach-title #approachTitle");
+        currentTitles.forEach(title => {
+          title.classList.toggle("title-showing", entry.isIntersecting);
+        })
 
-              const currentTitles2 = entry.target.querySelectorAll(".approach-title .subheading");
-              currentTitles2.forEach(title2 => {
-                title2.classList.toggle("title-showing", entry.isIntersecting);
-              })
-      
-              const currentParagraph = entry.target.querySelector(".approach-paragraph");
-              currentParagraph.classList.toggle("paragraph-showing", entry.isIntersecting);
-          })
-      },
-      {
-        rootMargin:'-50%',
-      }
-    )
+        const currentTitles2 = entry.target.querySelectorAll(".approach-title .subheading");
+        currentTitles2.forEach(title2 => {
+          title2.classList.toggle("title-showing", entry.isIntersecting);
+        })
+
+        const currentParagraph = entry.target.querySelector(".approach-paragraph");
+        currentParagraph.classList.toggle("paragraph-showing", entry.isIntersecting);
+      })
+    }, {
+      rootMargin: '-50%',
+    })
     approachWrappers.forEach(approach => {
-        observer.observe(approach)
+      observer.observe(approach)
     })
 
     var approaches = document.querySelectorAll('.title-paragraph-wrapper-approach');
-    var last = approaches[approaches.length- 1];
+    var last = approaches[approaches.length - 1];
     last.style.paddingBottom = "6rem";
   <?php endif ?>
 </script>

--- a/site/snippets/discover-more.php
+++ b/site/snippets/discover-more.php
@@ -1,24 +1,25 @@
-
 <div class="line-wrapper">
-  <div class="line"></div>
+   <div class="line"></div>
 </div>
 
 <div class="homepage-paragraph__two">
-  <h2><?= $site->wearekatalystparagraphtwo()->html() ?></h2>
-  <span class="link_wrapper__h2-homepage">
-    <?php if ($ourstudiourl = page('services')): endif;?>
+   <h2><?= $site->wearekatalystparagraphtwo()->html() ?></h2>
+   <span class="link_wrapper__h2-homepage">
+      <?php if ($ourstudiourl = page('services')): endif; ?>
       <p onclick="javascript:setTimeout(()=>{window.location = '<?= $ourstudiourl->url(); ?>' },1000);"
          class="insights__subtitle"
-         id="discoverMoreLinks"
-      >
+         id="discoverMoreLinks">
          <?= $site->wearekatalystparagraphtwotitle()->html() ?>
       </p>
-      <?php if ($insightsurl = page('news')): endif;?>
+      <?php if ($insightsurl = page('news')): endif; ?>
       <p onclick="javascript:setTimeout(()=>{window.location = '<?= $insightsurl->url(); ?>' },1000);"
          class="insights__subtitle"
-         id="discoverMoreLinks"
-      >
+         id="discoverMoreLinks">
          <?= $site->wearekatalystparagraphtwotitletwo()->html() ?>
       </p>
-  </span>
+   </span>
+</div>
+
+<div class="line-wrapper">
+   <div class="line"></div>
 </div>

--- a/site/snippets/footer-content.php
+++ b/site/snippets/footer-content.php
@@ -1,91 +1,81 @@
-
 <footer class="footer-homepage" id="footer">
-  <div class="line-wrapper">
-    <div class="line" id="footerLine"></div>
-  </div>
   <!-- <footer class="footer" id="footer"> -->
-    <div class="footer-paragraph-wrapper" id="footerCont">
-      <span class="left-side-paragraph">
-        <span>
-          <p class="list-title"><?= $site->footerlefttitle() ?></p>
-          <br>
-          <p class="main-paragraph"><?= $site->footerleftparagraph() ?></p>
-          <br>
-          <a class="footer-contact"
-             href="mailto:<?= $site->footerleftlink() ?>"
-          >
-            ⮡ Contact
-          </a>
-        </span>
-        <span class="copyright-mobile">
-          <p class="main-paragraph footercopyright">Copyright © <?= date("Y") ?> KATALYST™</p>
-        </span>
-        <span></span>
+  <div class="footer-paragraph-wrapper" id="footerCont">
+    <span class="left-side-paragraph">
+      <span>
+        <p class="list-title"><?= $site->footerlefttitle() ?></p>
+        <br>
+        <p class="main-paragraph"><?= $site->footerleftparagraph() ?></p>
+        <br>
+        <a class="footer-contact"
+          href="mailto:<?= $site->footerleftlink() ?>">
+          ⮡ Contact
+        </a>
       </span>
-      <span class="right-side-paragraphs-footer">
-        <span>
-          <p class="list-title"><?= $site->footerrightfirsttitle() ?></p>
-          <br>
-          <?php if ($site->footerrightfirstlinktwo()->isNotEmpty()): ?>
-            <?php foreach ($site->children()->listed()->offset(3)->paginate(1) as $item): ?>
-              <p class="main-paragraph blackpage-nav-item"
-                 id="footerLinks"
-                 onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);"
-              >
-                ⮡ <?= $site->footerrightfirstlinktwo() ?>
-              </p>
-            <?php endforeach ?>
-          <?php endif ?>
-          <?php if ($site->footerrightfirstlinkthree()->isNotEmpty()): ?>
-            <?php foreach ($site->children()->listed()->offset(4)->paginate(1) as $item): ?>
-              <p class="main-paragraph blackpage-nav-item"
-                 id="footerLinks"
-                 onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);"
-              >
-                ⮡ <?= $site->footerrightfirstlinkthree() ?>
-              </p>
-            <?php endforeach ?>
-          <?php endif ?>
-          <?php if ($site->footerrightfirstlinkfour()->isNotEmpty()): ?>
-            <?php foreach ($site->children()->listed()->offset(5)->paginate(1) as $item): ?>
-              <p class="main-paragraph blackpage-nav-item"
-                 id="footerLinks"
-                 onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);"
-              >
-                ⮡ <?= $site->footerrightfirstlinkfour() ?>
-              </p>
-            <?php endforeach ?>
-          <?php endif ?>
-        </span>
-        <span>
-          <p class="list-title"><?= $site->footerrightsecondtitle() ?></p>
-          <br>
-          <?php if ($site->footerrightsecondlinkone()->isNotEmpty()): ?>
-            <p href="<?= $site->footerrightsecondlinkonelink() ?>" 
-               target="blank" 
-               class="main-paragraph"
-               id="footerLinks"
-            >
-               ⮡ <?= $site->footerrightsecondlinkone() ?>
+      <span class="copyright-mobile">
+        <p class="main-paragraph footercopyright">Copyright © <?= date("Y") ?> KATALYST™</p>
+      </span>
+      <span></span>
+    </span>
+    <span class="right-side-paragraphs-footer">
+      <span>
+        <p class="list-title"><?= $site->footerrightfirsttitle() ?></p>
+        <br>
+        <?php if ($site->footerrightfirstlinktwo()->isNotEmpty()): ?>
+          <?php foreach ($site->children()->listed()->offset(3)->paginate(1) as $item): ?>
+            <p class="main-paragraph blackpage-nav-item"
+              id="footerLinks"
+              onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);">
+              ⮡ <?= $site->footerrightfirstlinktwo() ?>
             </p>
-          <?php endif ?>
-          <?php if ($site->footerrightsecondlinktwo()->isNotEmpty()): ?>
-            <p href="<?= $site->footerrightsecondlinktwolink() ?>" 
-               target="blank" 
-               class="main-paragraph"
-               id="footerLinks"
-            >
-               ⮡ <?= $site->footerrightsecondlinktwo() ?>
+          <?php endforeach ?>
+        <?php endif ?>
+        <?php if ($site->footerrightfirstlinkthree()->isNotEmpty()): ?>
+          <?php foreach ($site->children()->listed()->offset(4)->paginate(1) as $item): ?>
+            <p class="main-paragraph blackpage-nav-item"
+              id="footerLinks"
+              onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);">
+              ⮡ <?= $site->footerrightfirstlinkthree() ?>
             </p>
-            <br>
-          <?php endif ?>
-        </span>
-        <span class="copyright-desktop">
-          <p class="main-paragraph"><?= $site->copyright() ?></p>
-        </span>
-      </span> 
-    </div>
+          <?php endforeach ?>
+        <?php endif ?>
+        <?php if ($site->footerrightfirstlinkfour()->isNotEmpty()): ?>
+          <?php foreach ($site->children()->listed()->offset(5)->paginate(1) as $item): ?>
+            <p class="main-paragraph blackpage-nav-item"
+              id="footerLinks"
+              onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);">
+              ⮡ <?= $site->footerrightfirstlinkfour() ?>
+            </p>
+          <?php endforeach ?>
+        <?php endif ?>
+      </span>
+      <span>
+        <p class="list-title"><?= $site->footerrightsecondtitle() ?></p>
+        <br>
+        <?php if ($site->footerrightsecondlinkone()->isNotEmpty()): ?>
+          <p href="<?= $site->footerrightsecondlinkonelink() ?>"
+            target="blank"
+            class="main-paragraph"
+            id="footerLinks">
+            ⮡ <?= $site->footerrightsecondlinkone() ?>
+          </p>
+        <?php endif ?>
+        <?php if ($site->footerrightsecondlinktwo()->isNotEmpty()): ?>
+          <p href="<?= $site->footerrightsecondlinktwolink() ?>"
+            target="blank"
+            class="main-paragraph"
+            id="footerLinks">
+            ⮡ <?= $site->footerrightsecondlinktwo() ?>
+          </p>
+          <br>
+        <?php endif ?>
+      </span>
+      <span class="copyright-desktop">
+        <p class="main-paragraph"><?= $site->copyright() ?></p>
+      </span>
+    </span>
+  </div>
 
-    <h1 class="logo">KATALYST</h1>
+  <h1 class="logo">KATALYST</h1>
   <!-- </footer> -->
 </footer>

--- a/site/snippets/header.php
+++ b/site/snippets/header.php
@@ -1,170 +1,165 @@
-
 <!DOCTYPE html>
 <!-- (c) Katalyst 2024 -->
 <!-- Site Development; Felix Luke -->
 <!-- Site Design; Felix Luke & Jordan Smith  -->
 <html lang="en">
+
 <head>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
-    <link rel="shortcut icon" type="image/png" href="/favicon.ico">
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#000000">
-    <meta name="robots" content="index,follow">
-    <meta name="googlebot" content="index,follow">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="shortcut icon" type="image/png" href="/favicon.ico">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#000000">
+  <meta name="robots" content="index,follow">
+  <meta name="googlebot" content="index,follow">
 
-    <meta http-equiv="Expires" CONTENT="0">
-    <meta http-equiv="Pragma" CONTENT="no-cache">
-    <meta http-equiv="Cache-Control" CONTENT="no-cache">
+  <meta http-equiv="Expires" CONTENT="0">
+  <meta http-equiv="Pragma" CONTENT="no-cache">
+  <meta http-equiv="Cache-Control" CONTENT="no-cache">
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-170813881-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-170813881-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
 
-      gtag('config', 'UA-170813881-1');
-    </script>
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
 
-    <?php
-    $detect = $page->detect();
-    // https://github.com/serbanghita/Mobile-Detect/wiki/Code-examples
-    $detect->is('Chrome');
-    
-    $isMobile = $page->isMobile();
-    // or
-    $isMobile = Bnomei\MobileDetect::instance()->isMobile();
-    $isTablet = $page->isTablet();
-    ?>
+    gtag('config', 'UA-170813881-1');
+  </script>
 
-      <title><?= $site->title() ?></title>
-      <meta name="keywords" content="">
-      <meta name="subject" content="">
-      <meta name="description" content="<?= $site->about() ?>">
+  <?php
+  $detect = $page->detect();
+  // https://github.com/serbanghita/Mobile-Detect/wiki/Code-examples
+  $detect->is('Chrome');
 
-    <?= css('assets/scss/stylesheet.css') ?>
+  $isMobile = $page->isMobile();
+  // or
+  $isMobile = Bnomei\MobileDetect::instance()->isMobile();
+  $isTablet = $page->isTablet();
+  ?>
 
-    <?= css([
-      'assets/css/index.css',
-      '@auto'
-    ]) ?>
+  <title><?= $site->title() ?></title>
+  <meta name="keywords" content="">
+  <meta name="subject" content="">
+  <meta name="description" content="<?= $site->about() ?>">
+
+  <?= css('assets/scss/stylesheet.css') ?>
+
+  <?= css([
+    'assets/css/index.css',
+    '@auto'
+  ]) ?>
 </head>
 
 
 <body>
 
   <header class="header" id="header">
-    <?php if($logo = $site->image('logo.png')): ?>
+    <?php if ($logo = $site->image('logo.png')): ?>
       <span class="logo-wrapper">
         <h3 class="logo blackpage-nav-item"
-            id="pageNav"
-            onclick="javascript:setTimeout(()=>{window.location = '<?= $site->url() ?>' },1000);" 
-        >
+          id="pageNav"
+          onclick="javascript:setTimeout(()=>{window.location = '<?= $site->url() ?>' },1000);">
           KATALYST
         </h3>
       </span>
     <?php endif ?>
-      <nav class="menu-button">
-        <div id="menuToggle">
-          <input class="mobile-input" type="checkbox" />
-            <span class="lines"></span>
-            <span class="lines"></span>
-            <span class="lines"></span>
-         <ul id="menu">
-         </ul>
-        </div>
-      </nav>
-      <nav class="menu">
-        <?php foreach ($site->children()->listed()->paginate(1) as $item): ?>
-          <a
-            <?php e($item->isOpen(), 'aria-current="page"') ?> 
-            onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);"
-            class="page-nav-items projects-nav-item"
-          >
-            <?= $item->title()->esc() ?>
-          </a>
-        <?php endforeach ?>
-  
-        <?php foreach ($site->children()->listed()->offset(1)->paginate(2) as $item): ?>
+    <nav class="menu-button">
+      <div id="menuToggle">
+        <input class="mobile-input" type="checkbox" />
+        <span class="lines"></span>
+        <span class="lines"></span>
+        <span class="lines"></span>
+        <ul id="menu">
+        </ul>
+      </div>
+    </nav>
+    <nav class="menu">
+      <?php foreach ($site->children()->listed()->paginate(1) as $item): ?>
         <a
-          <?php e($item->isOpen(), 'aria-current="page"') ?> 
+          <?php e($item->isOpen(), 'aria-current="page"') ?>
           onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);"
-          class="page-nav-items blackpage-nav-item"
-        >
+          class="page-nav-items projects-nav-item">
           <?= $item->title()->esc() ?>
         </a>
-        <?php endforeach ?>
-  
-        <a href="mailto:<?= $site->footerleftlink() ?>"
-           class="contact-button"
-        >
-          Contact
+      <?php endforeach ?>
+
+      <?php foreach ($site->children()->listed()->offset(1)->paginate(2) as $item): ?>
+        <a
+          <?php e($item->isOpen(), 'aria-current="page"') ?>
+          onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);"
+          class="page-nav-items blackpage-nav-item">
+          <?= $item->title()->esc() ?>
         </a>
-      </nav>
+      <?php endforeach ?>
+
+      <a href="mailto:<?= $site->footerleftlink() ?>"
+        class="contact-button">
+        Contact
+      </a>
+    </nav>
   </header>
 
 
-    <div class="mobile-nav">
-      <nav class="menu-mobile">
-        <?php foreach ($site->children()->listed()->paginate(1) as $item): ?>
-          <a
-            <?php e($item->isOpen(), 'aria-current="page"') ?> 
-            onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);"
-            class="page-nav-items projects-nav-item"
-          >
-            <?= $item->title()->esc() ?>
-          </a>
-        <?php endforeach ?>
-  
-        <?php foreach ($site->children()->listed()->offset(1)->paginate(2) as $item): ?>
+  <div class="mobile-nav">
+    <nav class="menu-mobile">
+      <?php foreach ($site->children()->listed()->paginate(1) as $item): ?>
         <a
-          <?php e($item->isOpen(), 'aria-current="page"') ?> 
+          <?php e($item->isOpen(), 'aria-current="page"') ?>
           onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);"
-          class="page-nav-items blackpage-nav-item"
-        >
+          class="page-nav-items projects-nav-item">
           <?= $item->title()->esc() ?>
         </a>
-        <?php endforeach ?>
-  
-        <a href="mailto:<?= $site->footerleftlink() ?>"
-           class="contact-button"
-        >
-          Contact
+      <?php endforeach ?>
+
+      <?php foreach ($site->children()->listed()->offset(1)->paginate(2) as $item): ?>
+        <a
+          <?php e($item->isOpen(), 'aria-current="page"') ?>
+          onclick="javascript:setTimeout(()=>{window.location = '<?= $item->url() ?>' },1000);"
+          class="page-nav-items blackpage-nav-item">
+          <?= $item->title()->esc() ?>
         </a>
-      </nav>
+      <?php endforeach ?>
 
-      <div class="mobile-nav-socials">
-        <?php if ($site->footerrightsecondlinkone()->isNotEmpty()): ?>
-          <p href="<?= $site->footerrightsecondlinkonelink() ?>" 
-             target="blank" 
-             class="main-paragraph"
-             id="footerLinks"
-          >
-             ⮡ <?= $site->footerrightsecondlinkone() ?>
-          </p>
-        <?php endif ?>
-        <?php if ($site->footerrightsecondlinktwo()->isNotEmpty()): ?>
-          <p href="<?= $site->footerrightsecondlinktwolink() ?>" 
-             target="blank" 
-             class="main-paragraph"
-             id="footerLinks"
-          >
-             ⮡ <?= $site->footerrightsecondlinktwo() ?>
-          </p>
-        <?php endif ?>
-      </div>
+      <a href="mailto:<?= $site->footerleftlink() ?>"
+        class="contact-button">
+        Contact
+      </a>
+    </nav>
+
+    <div class="mobile-nav-socials">
+      <?php if ($site->footerrightsecondlinkone()->isNotEmpty()): ?>
+        <p href="<?= $site->footerrightsecondlinkonelink() ?>"
+          target="blank"
+          class="main-paragraph"
+          id="footerLinks">
+          ⮡ <?= $site->footerrightsecondlinkone() ?>
+        </p>
+      <?php endif ?>
+      <?php if ($site->footerrightsecondlinktwo()->isNotEmpty()): ?>
+        <p href="<?= $site->footerrightsecondlinktwolink() ?>"
+          target="blank"
+          class="main-paragraph"
+          id="footerLinks">
+          ⮡ <?= $site->footerrightsecondlinktwo() ?>
+        </p>
+      <?php endif ?>
     </div>
+  </div>
 
-  <?php if($page->isChildOf('work')): ?>
+  <?php if ($page->isChildOf('work')): ?>
     <style>
-
-      html, body {
-        background-color: var(--base-white);;
+      html,
+      body {
+        background-color: var(--base-white);
+        ;
       }
 
       meta {
@@ -205,14 +200,17 @@
       /* .menu a[aria-current] {
         color: var(--white-temp-text);
       } */
-    
+
       .menu-mobile a:hover {
         color: var(--white-temp-text);
       }
 
+      .scroll__container>section {
+        background-color: var(--base-white);
+      }
 
-      .scroll__container {
-          background-color: var(--base-white);
+      .scroll__container>*:nth-last-child(2) {
+        border-bottom: 0.75px solid var(--base-black);
       }
 
       footer.footer {
@@ -285,7 +283,7 @@
       .footer-contact {
         color: var(--white-temp-text);
       }
-      
+
       .footer-contact:hover {
         color: var(--base-black);
       }
@@ -293,15 +291,13 @@
       div#footerLine {
         background-color: var(--base-black);
       }
-
-
-
     </style>
-  <?php elseif($page->is('work')): ?>
+  <?php elseif ($page->is('work')): ?>
     <style>
-
-      html, body {
-        background-color: var(--base-white);;
+      html,
+      body {
+        background-color: var(--base-white);
+        ;
       }
 
       meta {
@@ -342,21 +338,26 @@
       /* .menu a[aria-current] {
         color: var(--white-temp-text);
       } */
-    
+
       .menu-mobile a:hover {
         color: var(--white-temp-text);
       }
 
 
-      .scroll__container {
-          background-color: var(--base-white);
+      .scroll__container>section {
+        background-color: var(--base-white);
+      }
+
+      .scroll__container>*:nth-last-child(2) {
+        border-bottom: 0.75px solid var(--base-black);
       }
 
       footer.footer {
         background-color: var(--base-white);
       }
 
-      h1, h2 {
+      h1,
+      h2 {
         color: var(--base-black);
       }
 
@@ -419,7 +420,7 @@
       .footer-contact {
         color: var(--white-temp-text);
       }
-      
+
       .footer-contact:hover {
         color: var(--base-black);
       }

--- a/site/snippets/recentwork.php
+++ b/site/snippets/recentwork.php
@@ -6,236 +6,215 @@
     <h2>More Work</h2>
   </span>
   <ul class="grid-recent-work">
-      <?php if ($prev = $page->prevListed()): ?>
-        <li class="column">
-          <a class="project-link projects-nav-item" 
-             onclick="javascript:setTimeout(()=>{window.location = '<?= $prev->url() ?>' },1000);"
-          >
+    <?php if ($prev = $page->prevListed()): ?>
+      <li class="column">
+        <a class="project-link projects-nav-item"
+          onclick="javascript:setTimeout(()=>{window.location = '<?= $prev->url() ?>' },1000);">
           <?php if ($coverone = $prev->coverone()->toFile()): ?>
             <span class="img">
               <?php if ($covertwo = $prev->covertwo()->toFile()): ?>
                 <span class="image_video_wrapper single-img-12-8">
                   <img src="<?= $covertwo->url() ?>"
-                       alt="<?= $covertwo->alt()->esc() ?>"
-                       class="project_image_alt"
-                  />
+                    alt="<?= $covertwo->alt()->esc() ?>"
+                    class="project_image_alt" />
                   <img src="<?= $coverone->url() ?>"
-                       onmouseover="this.style.opacity = 0"
-                       onmouseout="this.style.opacity = 1"
-                       alt="<?= $coverone->alt()->esc() ?>"
-                       class="project_image_alt"
-                  />
+                    onmouseover="this.style.opacity = 0"
+                    onmouseout="this.style.opacity = 1"
+                    alt="<?= $coverone->alt()->esc() ?>"
+                    class="project_image_alt" />
                 </span>
-              <?php elseif($video = $prev->video()->toFile()): ?>
+              <?php elseif ($video = $prev->video()->toFile()): ?>
                 <span class="image_video_wrapper single-img-12-8">
                   <video class="video"
-                         src="<?= $video->url() ?>"
-                         preload 
-                         autobuffer 
-                         muted 
-                         playsinline
-                         autoplay
-                         loop
-                  >
+                    src="<?= $video->url() ?>"
+                    preload
+                    autobuffer
+                    muted
+                    playsinline
+                    autoplay
+                    loop>
                   </video>
                   <img src="<?= $coverone->url() ?>"
-                       alt="<?= $coverone->alt()->esc() ?>"
-                       onmouseover="this.style.opacity = 0"
-                       onmouseout="this.style.opacity = 1"
-                       class="project_image_alt"
-                  >
+                    alt="<?= $coverone->alt()->esc() ?>"
+                    onmouseover="this.style.opacity = 0"
+                    onmouseout="this.style.opacity = 1"
+                    class="project_image_alt">
                 </span>
               <?php else: ?>
                 <span class="image_video_wrapper single-img-12-8">
                   <img src="<?= $coverone->url() ?>"
-                       alt="<?= $coverone->alt()->esc() ?>"
-                       class="project_image_alt"
-                  >
+                    alt="<?= $coverone->alt()->esc() ?>"
+                    class="project_image_alt">
                 </span>
               <?php endif ?>
             </span>
           <?php endif ?>
-              <figcaption class="img-caption">
-                <p class="project-heading"><?= $prev->title()->esc() ?></p>
-                <p class="subheading"><?= $prev->subheadline()->esc() ?></p>
-              </figcaption>
-          </a>
-        </li>
-      <?php endif ?>
+          <figcaption class="img-caption">
+            <p class="project-heading"><?= $prev->title()->esc() ?></p>
+            <p class="subheading"><?= $prev->subheadline()->esc() ?></p>
+          </figcaption>
+        </a>
+      </li>
+    <?php endif ?>
 
-      <?php if ($prev = $page->prevListed() == false ): ?>
-        <?php if ($next = $page->nextListed()->nextListed()): ?>
-          <li class="column">
-            <a class="project-link projects-nav-item"
-               onclick="javascript:setTimeout(()=>{window.location = '<?= $next->url() ?>' },1000);"
-            >
+    <?php if ($prev = $page->prevListed() == false): ?>
+      <?php if ($next = $page->nextListed()->nextListed()): ?>
+        <li class="column">
+          <a class="project-link projects-nav-item"
+            onclick="javascript:setTimeout(()=>{window.location = '<?= $next->url() ?>' },1000);">
             <?php if ($coverone = $next->coverone()->toFile()): ?>
               <span class="img">
                 <?php if ($covertwo = $next->covertwo()->toFile()): ?>
                   <span class="image_video_wrapper single-img-12-8">
                     <img src="<?= $covertwo->url() ?>"
-                         alt="<?= $covertwo->alt()->esc() ?>"
-                         class="project_image_alt"
-                    />
+                      alt="<?= $covertwo->alt()->esc() ?>"
+                      class="project_image_alt" />
                     <img src="<?= $coverone->url() ?>"
-                         onmouseover="this.style.opacity = 0"
-                         onmouseout="this.style.opacity = 1"
-                         alt="<?= $coverone->alt()->esc() ?>"
-                         class="project_image_alt"
-                    />
+                      onmouseover="this.style.opacity = 0"
+                      onmouseout="this.style.opacity = 1"
+                      alt="<?= $coverone->alt()->esc() ?>"
+                      class="project_image_alt" />
                   </span>
-                <?php elseif($video = $next->video()->toFile()): ?>
+                <?php elseif ($video = $next->video()->toFile()): ?>
                   <span class="image_video_wrapper single-img-12-8">
                     <video class="video"
-                           src="<?= $video->url() ?>"
-                           preload 
-                           autobuffer 
-                           muted 
-                           playsinline
-                           autoplay
-                           loop
-                    >
+                      src="<?= $video->url() ?>"
+                      preload
+                      autobuffer
+                      muted
+                      playsinline
+                      autoplay
+                      loop>
                     </video>
                     <img src="<?= $coverone->url() ?>"
-                         alt="<?= $coverone->alt()->esc() ?>"
-                         onmouseover="this.style.opacity = 0"
-                         onmouseout="this.style.opacity = 1"
-                         class="project_image_alt"
-                    >
+                      alt="<?= $coverone->alt()->esc() ?>"
+                      onmouseover="this.style.opacity = 0"
+                      onmouseout="this.style.opacity = 1"
+                      class="project_image_alt">
                   </span>
                 <?php else: ?>
                   <span class="image_video_wrapper single-img-12-8">
                     <img src="<?= $coverone->url() ?>"
-                         alt="<?= $coverone->alt()->esc() ?>"
-                         class="project_image_alt"
-                    >
+                      alt="<?= $coverone->alt()->esc() ?>"
+                      class="project_image_alt">
                   </span>
                 <?php endif ?>
               </span>
             <?php endif ?>
-                <figcaption class="img-caption">
-                  <p class="project-heading"><?= $next->title()->esc() ?></p>
-                  <p class="subheading"><?= $next->subheadline()->esc() ?></p>
-                </figcaption>
-            </a>
-          </li>
-        <?php endif ?>
+            <figcaption class="img-caption">
+              <p class="project-heading"><?= $next->title()->esc() ?></p>
+              <p class="subheading"><?= $next->subheadline()->esc() ?></p>
+            </figcaption>
+          </a>
+        </li>
       <?php endif ?>
+    <?php endif ?>
 
-      <?php if ($next = $page->nextListed()): ?>
-        <li class="column">
-          <a class="project-link projects-nav-item"
-             onclick="javascript:setTimeout(()=>{window.location = '<?= $next->url() ?>' },1000);"
-          >
+    <?php if ($next = $page->nextListed()): ?>
+      <li class="column">
+        <a class="project-link projects-nav-item"
+          onclick="javascript:setTimeout(()=>{window.location = '<?= $next->url() ?>' },1000);">
           <?php if ($coverone = $next->coverone()->toFile()): ?>
             <span class="img">
               <?php if ($covertwo = $next->covertwo()->toFile()): ?>
                 <span class="image_video_wrapper single-img-12-8">
                   <img src="<?= $covertwo->url() ?>"
-                       alt="<?= $covertwo->alt()->esc() ?>"
-                       class="project_image_alt"
-                  />
+                    alt="<?= $covertwo->alt()->esc() ?>"
+                    class="project_image_alt" />
                   <img src="<?= $coverone->url() ?>"
-                       onmouseover="this.style.opacity = 0"
-                       onmouseout="this.style.opacity = 1"
-                       alt="<?= $coverone->alt()->esc() ?>"
-                       class="project_image_alt"
-                  />
+                    onmouseover="this.style.opacity = 0"
+                    onmouseout="this.style.opacity = 1"
+                    alt="<?= $coverone->alt()->esc() ?>"
+                    class="project_image_alt" />
                 </span>
-              <?php elseif($video = $next->video()->toFile()): ?>
+              <?php elseif ($video = $next->video()->toFile()): ?>
                 <span class="image_video_wrapper single-img-12-8">
                   <video class="video"
-                         src="<?= $video->url() ?>"
-                         preload 
-                         autobuffer 
-                         muted 
-                         playsinline
-                         autoplay
-                         loop
-                  >
+                    src="<?= $video->url() ?>"
+                    preload
+                    autobuffer
+                    muted
+                    playsinline
+                    autoplay
+                    loop>
                   </video>
                   <img src="<?= $coverone->url() ?>"
-                       alt="<?= $coverone->alt()->esc() ?>"
-                       onmouseover="this.style.opacity = 0"
-                       onmouseout="this.style.opacity = 1"
-                       class="project_image_alt"
-                  >
+                    alt="<?= $coverone->alt()->esc() ?>"
+                    onmouseover="this.style.opacity = 0"
+                    onmouseout="this.style.opacity = 1"
+                    class="project_image_alt">
                 </span>
               <?php else: ?>
                 <span class="image_video_wrapper single-img-12-8">
                   <img src="<?= $coverone->url() ?>"
-                       alt="<?= $coverone->alt()->esc() ?>"
-                       class="project_image_alt"
-                  >
+                    alt="<?= $coverone->alt()->esc() ?>"
+                    class="project_image_alt">
                 </span>
               <?php endif ?>
             </span>
           <?php endif ?>
-              <figcaption class="img-caption">
-                <p class="project-heading"><?= $next->title()->esc() ?></p>
-                <p class="subheading"><?= $next->subheadline()->esc() ?></p>
-              </figcaption>
-          </a>
-        </li>
-      <?php endif ?>
+          <figcaption class="img-caption">
+            <p class="project-heading"><?= $next->title()->esc() ?></p>
+            <p class="subheading"><?= $next->subheadline()->esc() ?></p>
+          </figcaption>
+        </a>
+      </li>
+    <?php endif ?>
 
-      <?php if ($next = $page->nextListed() == false ): ?>
-        <?php if ($prev = $page->prevListed()->prevListed()): ?>
-          <li class="column">
-            <a class="project-link projects-nav-item"
-               onclick="javascript:setTimeout(()=>{window.location = '<?= $prev->url() ?>' },1000);"
-            >
+    <?php if ($next = $page->nextListed() == false): ?>
+      <?php if ($prev = $page->prevListed()->prevListed()): ?>
+        <li class="column">
+          <a class="project-link projects-nav-item"
+            onclick="javascript:setTimeout(()=>{window.location = '<?= $prev->url() ?>' },1000);">
             <?php if ($coverone = $prev->coverone()->toFile()): ?>
               <span class="img">
                 <?php if ($covertwo = $prev->covertwo()->toFile()): ?>
                   <span class="image_video_wrapper single-img-12-8">
                     <img src="<?= $covertwo->url() ?>"
-                         alt="<?= $covertwo->alt()->esc() ?>"
-                         class="project_image_alt"
-                    />
+                      alt="<?= $covertwo->alt()->esc() ?>"
+                      class="project_image_alt" />
                     <img src="<?= $coverone->url() ?>"
-                         onmouseover="this.style.opacity = 0"
-                         onmouseout="this.style.opacity = 1"
-                         alt="<?= $coverone->alt()->esc() ?>"
-                         class="project_image_alt"
-                    />
+                      onmouseover="this.style.opacity = 0"
+                      onmouseout="this.style.opacity = 1"
+                      alt="<?= $coverone->alt()->esc() ?>"
+                      class="project_image_alt" />
                   </span>
-                <?php elseif($video = $prev->video()->toFile()): ?>
+                <?php elseif ($video = $prev->video()->toFile()): ?>
                   <span class="image_video_wrapper single-img-12-8">
                     <video class="video"
-                           src="<?= $video->url() ?>"
-                           preload 
-                           autobuffer 
-                           muted 
-                           playsinline
-                           autoplay
-                           loop
-                    >
+                      src="<?= $video->url() ?>"
+                      preload
+                      autobuffer
+                      muted
+                      playsinline
+                      autoplay
+                      loop>
                     </video>
                     <img src="<?= $coverone->url() ?>"
-                         alt="<?= $coverone->alt()->esc() ?>"
-                         onmouseover="this.style.opacity = 0"
-                         onmouseout="this.style.opacity = 1"
-                         class="project_image_alt"
-                    >
+                      alt="<?= $coverone->alt()->esc() ?>"
+                      onmouseover="this.style.opacity = 0"
+                      onmouseout="this.style.opacity = 1"
+                      class="project_image_alt">
                   </span>
                 <?php else: ?>
                   <span class="image_video_wrapper single-img-12-8">
                     <img src="<?= $coverone->url() ?>"
-                         alt="<?= $coverone->alt()->esc() ?>"
-                         class="project_image_alt"
-                    >
+                      alt="<?= $coverone->alt()->esc() ?>"
+                      class="project_image_alt">
                   </span>
                 <?php endif ?>
               </span>
             <?php endif ?>
-                <figcaption class="img-caption">
-                  <p class="project-heading"><?= $prev->title()->esc() ?></p>
-                  <p class="subheading"><?= $prev->subheadline()->esc() ?></p>
-                </figcaption>
-            </a>
-          </li>
-        <?php endif ?>
+            <figcaption class="img-caption">
+              <p class="project-heading"><?= $prev->title()->esc() ?></p>
+              <p class="subheading"><?= $prev->subheadline()->esc() ?></p>
+            </figcaption>
+          </a>
+        </li>
       <?php endif ?>
+    <?php endif ?>
   </ul>
+  <div class="line-wrapper">
+    <div class="line" id="projectLine"></div>
+  </div>
 </div>

--- a/site/snippets/services.php
+++ b/site/snippets/services.php
@@ -1,12 +1,11 @@
-
 <style>
   @media screen and (max-width: 768px) {
     div.project__header {
-        height: 5vh;
+      height: 5vh;
     }
   }
 </style>
-
+<section>
   <?php $servicestab = $page->children()->listed()->offset(1)->paginate(1) ?>
   <?php foreach ($servicestab as $service): ?>
     <figcaption class="img-caption insight-date">
@@ -20,52 +19,50 @@
         <span>
           <h3><?= $service->servicessecondparagraph()->html() ?></h3>
         </span>
-      </span> 
+      </span>
     </div>
 
-    
+
     <div class="services-wrapper approach">
       <?php $servicecategories = $service->children()->listed() ?>
       <?php foreach ($servicecategories as $category): ?>
         <span class="category-wrapper image-service-wrapper">
-<!-- image -->
+          <!-- image -->
           <div class="image-wrapper">
             <?php $services = $category->children()->listed() ?>
             <?php foreach ($services as $singleservice): ?>
               <span class="service-image-wrapper">
                 <?php if ($image = $singleservice->files()->filterBy('type', 'image')->first()): ?>
                   <img class="service-image service"
-                    src="<?= $image->url() ?>"
-                  >
+                    src="<?= $image->url() ?>">
                 <?php elseif ($video =  $singleservice->files()->filterBy('type', 'video')->first()): ?>
                   <video class="service-image service"
-                         src="<?= $video->url() ?>" 
-                         type="<?= $video->mime() ?>" 
-                         id="news-img" 
-                         autoplay 
-                         muted 
-                         loop 
-                         playsinline 
-                  >
+                    src="<?= $video->url() ?>"
+                    type="<?= $video->mime() ?>"
+                    id="news-img"
+                    autoplay
+                    muted
+                    loop
+                    playsinline>
                   </video>
                 <?php endif ?>
               </span>
             <?php endforeach; ?>
-            </div>
-<!-- category -->
+          </div>
+          <!-- category -->
           <!-- <div class="category-service-wrapper">
             <div></div>
             <div>
               <p class="service"><?= $category->title()->html() ?></p>
             </div>
           </div> -->
-<!-- title -->
+          <!-- title -->
           <div class="title-service-wrapper">
             <?php $services = $category->children()->listed() ?>
             <?php foreach ($services as $singleservice): ?>
-            <span class="service-title-wrapper">
-              <h2 class="service"><?= $singleservice->service()->html() ?></h2>
-            </span>
+              <span class="service-title-wrapper">
+                <h2 class="service"><?= $singleservice->service()->html() ?></h2>
+              </span>
             <?php endforeach; ?>
           </div>
 
@@ -73,57 +70,51 @@
       <?php endforeach; ?>
     </div>
   <?php endforeach; ?>
-
+</section>
 
 
 <script>
-
-    const titleServiceWrappers = document.querySelectorAll(".service-title-wrapper");
-    const titleServiceWrapperObserver = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        // entry.target.classList.toggle("show", entry.isIntersecting);
-        const currentTitle = entry.target.querySelector(".service");
-        currentTitle.classList.toggle("title-showing", entry.isIntersecting);
-        // console.log(currentTitle)
-      })
-    },
-      {
-        rootMargin:'-50%',
-      }
-    )
-
-    titleServiceWrappers.forEach(title => {
-      titleServiceWrapperObserver.observe(title)
+  const titleServiceWrappers = document.querySelectorAll(".service-title-wrapper");
+  const titleServiceWrapperObserver = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      // entry.target.classList.toggle("show", entry.isIntersecting);
+      const currentTitle = entry.target.querySelector(".service");
+      currentTitle.classList.toggle("title-showing", entry.isIntersecting);
+      // console.log(currentTitle)
     })
+  }, {
+    rootMargin: '-50%',
+  })
+
+  titleServiceWrappers.forEach(title => {
+    titleServiceWrapperObserver.observe(title)
+  })
 
 
-    const imageServiceWrappers = document.querySelectorAll(".service-image-wrapper");
-    console.log(imageServiceWrappers)
-    const imageServiceWrapperObserver = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        // entry.target.classList.toggle("show", entry.isIntersecting);
-        const currentTitle = entry.target.querySelector(".service");
-        currentTitle.classList.toggle("image-showing", entry.isIntersecting);
-        // console.log(currentTitle)
-      })
-    },
-      {
-        rootMargin:'-50%',
-      }
-    )
-
-    imageServiceWrappers.forEach(image => {
-      imageServiceWrapperObserver.observe(image)
+  const imageServiceWrappers = document.querySelectorAll(".service-image-wrapper");
+  console.log(imageServiceWrappers)
+  const imageServiceWrapperObserver = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      // entry.target.classList.toggle("show", entry.isIntersecting);
+      const currentTitle = entry.target.querySelector(".service");
+      currentTitle.classList.toggle("image-showing", entry.isIntersecting);
+      // console.log(currentTitle)
     })
+  }, {
+    rootMargin: '-50%',
+  })
 
-    <?php if ($page->isMobile()): ?>  
-      var services = document.querySelectorAll('.image-service-wrapper');
-      var last = services[services.length- 1];
-      last.style.paddingBottom = "5rem";
-    <?php else: ?>
-        var services = document.querySelectorAll('.image-service-wrapper');
-        var last = services[services.length- 1];
-        last.style.paddingBottom = "10rem";
-    <?php endif ?>
+  imageServiceWrappers.forEach(image => {
+    imageServiceWrapperObserver.observe(image)
+  })
 
+  <?php if ($page->isMobile()): ?>
+    var services = document.querySelectorAll('.image-service-wrapper');
+    var last = services[services.length - 1];
+    last.style.paddingBottom = "5rem";
+  <?php else: ?>
+    var services = document.querySelectorAll('.image-service-wrapper');
+    var last = services[services.length - 1];
+    last.style.paddingBottom = "10rem";
+  <?php endif ?>
 </script>

--- a/site/templates/about.php
+++ b/site/templates/about.php
@@ -1,97 +1,93 @@
-
 <?php snippet('header') ?>
 
 <?php snippet('layouts', ['field' => $page->layout()])  ?>
 
 <style>
   li.column {
-      margin-bottom: 0px;
+    margin-bottom: 0px;
   }
 
   /* section.footer-block {
     display: none;
   } */
-
 </style>
 
 <article class="ourstudio article">
-   <div class="scroll__container">
-     <section id="header">
+  <div class="scroll__container">
+    <section id="header">
       <div class="title-wrapper about-header">
         <div></div>
         <div class="project__header">
           <span class="link_wrapper__h1">
-              <h2><?= $page->intro()->esc() ?></h2>
+            <h2><?= $page->intro()->esc() ?></h2>
           </span>
         </div>
       </div>
     </section>
 
-     <div class="line-wrapper" id="projectTopLine">
-       <div class="line"></div>
-     </div>
+    <div class="line-wrapper" id="projectTopLine">
+      <div class="line"></div>
+    </div>
 
-     <?php snippet('approachandprocess') ?>
+    <?php snippet('approachandprocess') ?>
 
-     <div class="line-wrapper" id="projectTopLine">
-       <div class="line"></div>
-     </div>
+    <div class="line-wrapper" id="projectTopLine">
+      <div class="line"></div>
+    </div>
 
-     <?php snippet('services') ?>
+    <?php snippet('services') ?>
 
-     <div class="line-wrapper" id="projectTopLine">
-       <div class="line"></div>
-     </div>
+    <div class="line-wrapper" id="projectTopLine">
+      <div class="line"></div>
+    </div>
 
-     <?php snippet('clients') ?>
+    <?php snippet('clients') ?>
 
-     <style>
-       .email-prefooter-wrapper {
-         display: grid;
-         grid-template-columns: 1fr;;
-         padding-top:var(--single-space);
-         padding-bottom: var(--pent-space);
-         padding-left: var(--padding);
-         padding-right: var(--padding);
-       }
-     
-       @media screen and (max-width: 768px) {
-         .email-prefooter-wrapper {
-           display: grid;
-           grid-template-columns: 1fr;
-           width: 80vw;
-           padding-top:var(--mobile-double-space);
-           padding-bottom: var(--mobile-pent-space);
-         }
-       }
-     </style>
-     
-     <div class="line-wrapper">
-       <div class="line"></div>
-     </div>
-     
-     <div class="email-prefooter-wrapper">
-       <span>
-         <h2>Has your brand got a story to tell?</h2>
-       </span>
-       <span>
-         <a href="mailto:hello@designbykatalyst.com"
-            class="large-mail aboutpage"
-         >
-           ⮡ hello@designbykatalyst.com
-         </a>
-       </span> 
-     </div>
-     
-     <div class="line-wrapper desktop">
-       <div class="line"></div>
-     </div>
+    <style>
+      .email-prefooter-wrapper {
+        display: grid;
+        grid-template-columns: 1fr;
+        ;
+        padding-top: var(--single-space);
+        padding-bottom: var(--pent-space);
+        padding-left: var(--padding);
+        padding-right: var(--padding);
+        box-sizing: border-box;
+      }
 
-     <section class="footer-block">
+      @media screen and (max-width: 768px) {
+        .email-prefooter-wrapper {
+          display: grid;
+          grid-template-columns: 1fr;
+          width: 80vw;
+          padding-top: var(--mobile-double-space);
+          padding-bottom: var(--mobile-pent-space);
+        }
+      }
+    </style>
+
+    <div class="line-wrapper">
+      <div class="line"></div>
+    </div>
+
+    <section class="email-prefooter-wrapper">
+      <span>
+        <h2>Has your brand got a story to tell?</h2>
+      </span>
+      <span>
+        <a href="mailto:hello@designbykatalyst.com"
+          class="large-mail aboutpage">
+          ⮡ hello@designbykatalyst.com
+        </a>
+      </span>
+    </section>
+
+    <section class="footer-block">
       <?php snippet('footer-content') ?>
     </section>
 
-   </div>
+  </div>
+
 </article>
 
 <script type="module" src="./assets/js/app.js"></script>
@@ -116,7 +112,7 @@
 <script>
   const projectItems = document.querySelectorAll(".projects-nav-item");
   projectItems.forEach(projectItem => {
-    projectItem.addEventListener("click", function(){
+    projectItem.addEventListener("click", function() {
       loader.style.transform = "translateY(0%)";
       const header = document.querySelector(".header");
       const html = document.documentElement;

--- a/site/templates/about.php
+++ b/site/templates/about.php
@@ -59,7 +59,8 @@
         .email-prefooter-wrapper {
           display: grid;
           grid-template-columns: 1fr;
-          width: 80vw;
+          width: 100vw;
+          padding-right: 20vw;
           padding-top: var(--mobile-double-space);
           padding-bottom: var(--mobile-pent-space);
         }

--- a/site/templates/album.php
+++ b/site/templates/album.php
@@ -1,4 +1,3 @@
-
 <?php snippet('header') ?>
 
 <article class="article">
@@ -14,6 +13,7 @@
                 display: block;
                 gap: var(--padding);
               }
+
               /* div.project__header {
                   padding-top: 25vh;
               } */
@@ -28,16 +28,16 @@
         <span class="right-site-paragraph">
           <span>
           </span>
-          <span>  
+          <span>
           </span>
-        </span> 
+        </span>
       </div>
     </section>
 
     <div class="line-wrapper" id="projectTopLine">
       <div class="top-line" id="projectLine"></div>
     </div>
-  
+
     <section class="project-inital">
       <div class="project__header__specs">
         <span>
@@ -76,10 +76,10 @@
             <p class="main-paragraph"><?= $page->initaltitlethreefive()->html() ?></p>
             <p class="main-paragraph"><?= $page->initaltitlethreesix()->html() ?></p>
           </span>
-        </span> 
+        </span>
       </div>
-    </section> 
-  
+    </section>
+
     <section class="project-grid">
       <div class="project__start">
         <?= $page->blocks()->toBlocks() ?>
@@ -94,10 +94,8 @@
       <?php snippet('footer-content') ?>
     </section>
 
-    <!-- <section class="footer-gap">
-      <div id="footerGap"></div>
-    </section> -->
   </div>
+
 </article>
 
 <!-- <div id="footerGap"></div> -->
@@ -122,10 +120,9 @@
 <?php snippet('footer') ?>
 
 <script>
-
-const blackpageItems = document.querySelectorAll(".blackpage-nav-item");
+  const blackpageItems = document.querySelectorAll(".blackpage-nav-item");
   blackpageItems.forEach(blackpageItem => {
-    blackpageItem.addEventListener("click", function(){
+    blackpageItem.addEventListener("click", function() {
       loader.style.transform = "translateY(0%)";
       const header = document.querySelector(".header");
       const html = document.documentElement;

--- a/site/templates/cookies.php
+++ b/site/templates/cookies.php
@@ -1,16 +1,15 @@
-
 <?php snippet('header') ?>
 
 <style>
-    .title-paragraph-wrapper {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: var(--padding);
-        padding-left: var(--padding);
-        padding-right: var(--padding);
-        padding-top: var(--quad-space);
-        padding-bottom: var(--pent-space);
-    }
+  .title-paragraph-wrapper {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--padding);
+    padding-left: var(--padding);
+    padding-right: var(--padding);
+    padding-top: var(--quad-space);
+    padding-bottom: var(--pent-space);
+  }
 </style>
 
 <article class="article">
@@ -26,17 +25,19 @@
     <div class="line-wrapper" id="projectTopLine">
       <div class="top-line"></div>
     </div>
-    
+
     <section class="discover-section">
-        <?= $page->blocks()->toBlocks() ?>
+      <?= $page->blocks()->toBlocks() ?>
     </section>
 
     <section class="footer-block">
       <?php snippet('footer-content') ?>
     </section>
+
   </div>
+
 </article>
-    
+
 <?php snippet('footer') ?>
 
 <script>
@@ -50,7 +51,7 @@
 <script>
   const projectItems = document.querySelectorAll(".projects-nav-item");
   projectItems.forEach(projectItem => {
-    projectItem.addEventListener("click", function(){
+    projectItem.addEventListener("click", function() {
       loader.style.transform = "translateY(0%)";
 
       const header = document.querySelector(".header");
@@ -63,17 +64,17 @@
 
   var question = document.querySelectorAll('.discover-section');
 
-var first = document.querySelectorAll('.discover-section').item(0);;
-first.style.paddingTop= "35vh";
+  var first = document.querySelectorAll('.discover-section').item(0);;
+  first.style.paddingTop = "35vh";
 
-var last = question[question.length- 1];
-<?php if ($page->isMobile()): ?>  
-  last.style.paddingBottom = "var(--mobile-pent-space)";
-<?php else: ?>
-  last.style.paddingBottom = "var(--pent-space)";
-<?php endif ?>
+  var last = question[question.length - 1];
+  <?php if ($page->isMobile()): ?>
+    last.style.paddingBottom = "var(--mobile-pent-space)";
+  <?php else: ?>
+    last.style.paddingBottom = "var(--pent-space)";
+  <?php endif ?>
 
-var titles = document.querySelectorAll(".title-paragraph-wrapper");
-var lastTitle = titles[titles.length- 1];
-lastTitle.style.paddingBottom = "0px";
+  var titles = document.querySelectorAll(".title-paragraph-wrapper");
+  var lastTitle = titles[titles.length - 1];
+  lastTitle.style.paddingBottom = "0px";
 </script>

--- a/site/templates/faqs.php
+++ b/site/templates/faqs.php
@@ -1,4 +1,3 @@
-
 <?php snippet('header') ?>
 
 <article class="article">
@@ -14,66 +13,68 @@
     <div class="line-wrapper" id="projectTopLine">
       <div class="top-line"></div>
     </div>
-    
+
     <section class="discover-section">
-        <?= $page->blocks()->toBlocks() ?>
+      <?= $page->blocks()->toBlocks() ?>
     </section>
 
     <section class="footer-block">
       <?php snippet('footer-content') ?>
     </section>
+
   </div>
+
 </article>
 
 <style>
+  .title-paragraph-wrapper {
+    padding-left: var(--padding);
+    padding-right: var(--padding);
+    padding-bottom: var(--tripple-space);
+    padding-top: 0px;
+  }
+
+  h2 {
+    font-size: var(--subtitle-2-copy-size);
+    line-height: var(--subtitle-2-copy-lineheight);
+    font-weight: normal;
+    color: var(--base-paper);
+  }
+
+  @media screen and (max-width: 768px) {
+    h2 {
+      font-size: var(--subtitle-2-copy-size-mobile);
+      line-height: var(--subtitle-2-copy-lineheight-mobile);
+    }
+
     .title-paragraph-wrapper {
       padding-left: var(--padding);
       padding-right: var(--padding);
       padding-bottom: var(--tripple-space);
+      padding-bottom: var(--mobile-pent-space);
       padding-top: 0px;
     }
-
-    h2 {
-      font-size: var(--subtitle-2-copy-size);
-      line-height: var(--subtitle-2-copy-lineheight);
-      font-weight: normal;
-      color: var(--base-paper);
-    }
-
-    @media screen and (max-width: 768px) {
-      h2 {
-        font-size: var(--subtitle-2-copy-size-mobile);
-        line-height: var(--subtitle-2-copy-lineheight-mobile);
-      }
-
-      .title-paragraph-wrapper {
-        padding-left: var(--padding);
-        padding-right: var(--padding);
-        padding-bottom: var(--tripple-space);
-        padding-bottom: var(--mobile-pent-space);
-        padding-top: 0px;
-      }
-    }
+  }
 </style>
 
 <script>
-      var question = document.querySelectorAll('.discover-section');
+  var question = document.querySelectorAll('.discover-section');
 
-      var first = document.querySelectorAll('.discover-section').item(0);;
-      first.style.paddingTop= "35vh";
+  var first = document.querySelectorAll('.discover-section').item(0);;
+  first.style.paddingTop = "35vh";
 
-      var last = question[question.length- 1];
-      <?php if ($page->isMobile()): ?>  
-        last.style.paddingBottom = "var(--mobile-pent-space)";
-      <?php else: ?>
-        last.style.paddingBottom = "var(--pent-space)";
-      <?php endif ?>
+  var last = question[question.length - 1];
+  <?php if ($page->isMobile()): ?>
+    last.style.paddingBottom = "var(--mobile-pent-space)";
+  <?php else: ?>
+    last.style.paddingBottom = "var(--pent-space)";
+  <?php endif ?>
 
-      var titles = document.querySelectorAll(".title-paragraph-wrapper");
-      var lastTitle = titles[titles.length- 1];
-      lastTitle.style.paddingBottom = "0px";
+  var titles = document.querySelectorAll(".title-paragraph-wrapper");
+  var lastTitle = titles[titles.length - 1];
+  lastTitle.style.paddingBottom = "0px";
 </script>
-    
+
 <?php snippet('footer') ?>
 
 <script>
@@ -87,7 +88,7 @@
 <script>
   const projectItems = document.querySelectorAll(".projects-nav-item");
   projectItems.forEach(projectItem => {
-    projectItem.addEventListener("click", function(){
+    projectItem.addEventListener("click", function() {
       loader.style.transform = "translateY(0%)";
 
       const header = document.querySelector(".header");

--- a/site/templates/home.php
+++ b/site/templates/home.php
@@ -1,60 +1,60 @@
-
 <?php snippet('header') ?>
 
 <article class="homepage">
   <div class="scroll__container">
     <section id="hero">
-         <div class="hero__container">
-             <div class="hero__title">
-                 <h1 class="hero__title__header text__reveal"><?= $site->initallineone()->html() ?></h1>
-                 <h1 class="hero__title__header text__reveal__second"><?= $site->initallinetwo()->html() ?></h1>
-             </div>
-         </div>
-     </section>
-    
-     <section id="video">
-       <div class="video__sticky">
-         <?php $video = $site->initalvideo()->toFile(); ?>
-         <video class="main__video" 
-                autoplay 
-                muted 
-                loop 
-                playsinline 
-                src="<?= $video->url() ?>"
-         >
-         </video>
-       </div>
-     </section>
-    
-     <section>
-       <div class="homepage-paragraph__one">
-         <h2>
-          <?= $site->wearekatalystparagraphone()->html() ?>
-         </h2>
-       </div>
-     </section>
-  
-     <section class="recent-work">
-       <?php snippet('recentwork-homepage') ?>
-     </section>
-  
-     <section class="discover-section">
-      <?php snippet('discover-more') ?>
-     </section>
+      <div class="hero__container">
+        <div class="hero__title">
+          <h1 class="hero__title__header text__reveal"><?= $site->initallineone()->html() ?></h1>
+          <h1 class="hero__title__header text__reveal__second"><?= $site->initallinetwo()->html() ?></h1>
+        </div>
+      </div>
+    </section>
 
-     <section class="footer-block">
+    <section id="video">
+      <div class="video__sticky">
+        <?php $video = $site->initalvideo()->toFile(); ?>
+        <video class="main__video"
+          autoplay
+          muted
+          loop
+          playsinline
+          src="<?= $video->url() ?>">
+        </video>
+      </div>
+    </section>
+
+    <section>
+      <div class="homepage-paragraph__one">
+        <h2>
+          <?= $site->wearekatalystparagraphone()->html() ?>
+        </h2>
+      </div>
+    </section>
+
+    <section class="recent-work">
+      <?php snippet('recentwork-homepage') ?>
+    </section>
+
+    <section class="discover-section">
+      <?php snippet('discover-more') ?>
+    </section>
+
+    <section class="footer-block">
       <?php snippet('footer-content') ?>
-     </section>
+    </section>
+
   </div>
+
 </article>
-  
+
 <script type="module" src="./assets/js/app.js"></script>
 <script type="module" src="./assets/js/homepageapp.js"></script>
 
 <script>
   const projectItems = document.querySelectorAll(".projects-nav-item");
   projectItems.forEach(projectItem => {
-    projectItem.addEventListener("click", function(){
+    projectItem.addEventListener("click", function() {
       loader.style.transform = "translateY(0%)";
       const header = document.querySelector(".header");
       const html = document.documentElement;

--- a/site/templates/insight.php
+++ b/site/templates/insight.php
@@ -1,4 +1,3 @@
-
 <?php snippet('header') ?>
 
 <article class="article">
@@ -8,7 +7,7 @@
         <div></div>
         <div class="project__header insight-header">
           <span class="insight-title-mobile">
-              <h2><?= $page->title()->esc() ?>:</h2>
+            <h2><?= $page->title()->esc() ?>:</h2>
           </span>
           <h2 class="insight__subtitle"><?= $page->subtitle()->esc() ?></h2>
         </div>
@@ -34,15 +33,15 @@
           <?php endif ?>
           <span>
             <span>
-            <p>Written by <?= $page->author()->esc() ?></p>
-            <p class="main-paragraph"><?= $page->authortitle()->esc() ?></p>
+              <p>Written by <?= $page->author()->esc() ?></p>
+              <p class="main-paragraph"><?= $page->authortitle()->esc() ?></p>
             </span>
             <?php if ($page->isMobile()): ?>
             <?php else: ?>
               <span></span>
               <span></span>
             <?php endif ?>
-          </span> 
+          </span>
         </div>
       </div>
     </section>
@@ -50,11 +49,12 @@
     <section class="footer-block">
       <?php snippet('footer-content') ?>
     </section>
+
   </div>
+
 </article>
 
 <style>
-
   p.project-heading {
     color: var(--base-white);
   }
@@ -125,12 +125,12 @@
     }
 
     h2.insight__subtitle {
-        font-size: var(--subtitle-copy-size-mobile);
-        line-height: var(--subtitle-copy-lineheight-mobile);
-        font-weight: normal;
-        color: var(--black-temp-text);
-        padding-bottom: 1vh;
-        margin-top: -1vh;
+      font-size: var(--subtitle-copy-size-mobile);
+      line-height: var(--subtitle-copy-lineheight-mobile);
+      font-weight: normal;
+      color: var(--black-temp-text);
+      padding-bottom: 1vh;
+      margin-top: -1vh;
     }
   }
 </style>
@@ -148,7 +148,7 @@
 <script>
   const projectItems = document.querySelectorAll(".projects-nav-item");
   projectItems.forEach(projectItem => {
-    projectItem.addEventListener("click", function(){
+    projectItem.addEventListener("click", function() {
       loader.style.transform = "translateY(0%)";
 
       const header = document.querySelector(".header");

--- a/site/templates/insights.php
+++ b/site/templates/insights.php
@@ -1,4 +1,3 @@
-
 <?php snippet('header') ?>
 
 <article class="article">
@@ -22,22 +21,21 @@
         <span class="right-side-paragraphs">
           <span class="project-initals">
             <p id="filterButton"
-               class="title_link insight-link active"
-               data-filter="all"
-            >
+              class="title_link insight-link active"
+              data-filter="all">
               All Insights [<?php echo ($page->children()->listed()->count()); ?>]
             </p>
 
-            <?php 
+            <?php
             $tags = $page->children()->listed()->pluck('dataname', ',', true);
             foreach ($tags as $tag):
-                $totalDataNames = $page->children()->listed()->filterBy('dataname', $tag)->count();
+              $totalDataNames = $page->children()->listed()->filterBy('dataname', $tag)->count();
             ?>
-                <p id="filterButton" 
-                   class="title_link insight-link <?= $tag ?>" 
-                   data-filter="<?= $tag ?>">
-                    <?= $tag ?>  [<?= $totalDataNames ?>]
-                </p>
+              <p id="filterButton"
+                class="title_link insight-link <?= $tag ?>"
+                data-filter="<?= $tag ?>">
+                <?= $tag ?> [<?= $totalDataNames ?>]
+              </p>
             <?php endforeach ?>
           </span>
           <span>
@@ -47,41 +45,38 @@
           <?php endif ?>
           <span>
           </span>
-        </span> 
+        </span>
       </div>
-    </section> 
-    
+    </section>
+
     <section>
       <ul class="insight_grid">
         <?php foreach ($page->children()->listed() as $insight): ?>
-        <li class="column"
-            data-name="<?= $insight->dataname() ?>"
-        >
-        <article class="note-excerpt">
-          <a id="titleLink"
-             onclick="javascript:setTimeout(()=>{window.location = '<?= $insight->url() ?>' },1000);"
-          >
-            <div class="insight_wrapper">
-              <!-- <figure class="insight_img"> -->
-                <span class="insight-img">
-                    <img src="<?= $insight->coverimage()->toFile()->url() ?>" 
-                         alt="<?= $insight->coverimage()->alt()->esc() ?>"
-                         id="<?= $insight->parallax() ?>"
-                    >
-                </span>
-              <!-- </figure> -->
-              <div class="insight_preview_text">
-                <p><?= $insight->datetext()->esc() ?></p>
-                <p class="insights__title"><?= $insight->title()->esc() ?> :</p>
-                <p class="insights__subtitle"><?= $insight->subtitle()->esc() ?></p>
-              </div>
-              <div class="insight_preview_text read_more_wrapper">
-                <p class="title_link">⮡ Read More</p>
-              </div>
-            </div>
-          </a>
-        </article>
-        </li>
+          <li class="column"
+            data-name="<?= $insight->dataname() ?>">
+            <article class="note-excerpt">
+              <a id="titleLink"
+                onclick="javascript:setTimeout(()=>{window.location = '<?= $insight->url() ?>' },1000);">
+                <div class="insight_wrapper">
+                  <!-- <figure class="insight_img"> -->
+                  <span class="insight-img">
+                    <img src="<?= $insight->coverimage()->toFile()->url() ?>"
+                      alt="<?= $insight->coverimage()->alt()->esc() ?>"
+                      id="<?= $insight->parallax() ?>">
+                  </span>
+                  <!-- </figure> -->
+                  <div class="insight_preview_text">
+                    <p><?= $insight->datetext()->esc() ?></p>
+                    <p class="insights__title"><?= $insight->title()->esc() ?> :</p>
+                    <p class="insights__subtitle"><?= $insight->subtitle()->esc() ?></p>
+                  </div>
+                  <div class="insight_preview_text read_more_wrapper">
+                    <p class="title_link">⮡ Read More</p>
+                  </div>
+                </div>
+              </a>
+            </article>
+          </li>
         <?php endforeach ?>
       </ul>
     </section>
@@ -89,7 +84,9 @@
     <section class="footer-block">
       <?php snippet('footer-content') ?>
     </section>
+
   </div>
+
 </article>
 
 <?php snippet('footer') ?>
@@ -105,9 +102,9 @@
 <script>
   const projectItems = document.querySelectorAll(".projects-nav-item");
   projectItems.forEach(projectItem => {
-    projectItem.addEventListener("click", function(){
+    projectItem.addEventListener("click", function() {
       loader.style.transform = "translateY(0%)";
-  
+
       const header = document.querySelector(".header");
       const html = document.documentElement;
       const body = document.querySelector("body");

--- a/site/templates/privacy-policy.php
+++ b/site/templates/privacy-policy.php
@@ -1,9 +1,8 @@
-
 <?php snippet('header') ?>
 
 
 <style>
-    .title-paragraph-wrapper {
+  .title-paragraph-wrapper {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: var(--padding);
@@ -11,14 +10,14 @@
     padding-right: var(--padding);
     padding-top: var(--quad-space);
     padding-bottom: var(--pent-space);
-}
-
-@media screen and (max-width: 768px) {
-    section.privacy-section {
-    margin-bottom: var(--mobile-pent-space);;
   }
-}
 
+  @media screen and (max-width: 768px) {
+    section.privacy-section {
+      margin-bottom: var(--mobile-pent-space);
+      ;
+    }
+  }
 </style>
 
 <article class="article">
@@ -34,17 +33,19 @@
     <div class="line-wrapper" id="projectTopLine">
       <div class="top-line"></div>
     </div>
-    
+
     <section class="discover-section">
-        <?= $page->blocks()->toBlocks() ?>
+      <?= $page->blocks()->toBlocks() ?>
     </section>
 
     <section class="footer-block">
       <?php snippet('footer-content') ?>
     </section>
+
   </div>
+
 </article>
-    
+
 <?php snippet('footer') ?>
 
 <script>
@@ -58,7 +59,7 @@
 <script>
   const projectItems = document.querySelectorAll(".projects-nav-item");
   projectItems.forEach(projectItem => {
-    projectItem.addEventListener("click", function(){
+    projectItem.addEventListener("click", function() {
       loader.style.transform = "translateY(0%)";
 
       const header = document.querySelector(".header");
@@ -67,19 +68,19 @@
       html.classList.add("active");
     })
   })
-      var question = document.querySelectorAll('.discover-section');
+  var question = document.querySelectorAll('.discover-section');
 
-      var first = document.querySelectorAll('.discover-section').item(0);;
-      first.style.paddingTop= "30vh";
+  var first = document.querySelectorAll('.discover-section').item(0);;
+  first.style.paddingTop = "30vh";
 
-      var last = question[question.length- 1];
-      <?php if ($page->isMobile()): ?>  
-        last.style.paddingBottom = "var(--mobile-pent-space)";
-      <?php else: ?>
-        last.style.paddingBottom = "var(--pent-space)";
-      <?php endif ?>
+  var last = question[question.length - 1];
+  <?php if ($page->isMobile()): ?>
+    last.style.paddingBottom = "var(--mobile-pent-space)";
+  <?php else: ?>
+    last.style.paddingBottom = "var(--pent-space)";
+  <?php endif ?>
 
-      var titles = document.querySelectorAll(".title-paragraph-wrapper");
-      var lastTitle = titles[titles.length- 1];
-      lastTitle.style.paddingBottom = "0px";
+  var titles = document.querySelectorAll(".title-paragraph-wrapper");
+  var lastTitle = titles[titles.length - 1];
+  lastTitle.style.paddingBottom = "0px";
 </script>

--- a/site/templates/work.php
+++ b/site/templates/work.php
@@ -1,4 +1,3 @@
-
 <?php snippet('header') ?>
 
 <style>
@@ -16,14 +15,14 @@
 
   @media screen and (max-width: 1000px) {
     li.column {
-        padding-top: 0px;
+      padding-top: 0px;
     }
   }
 
   @media screen and (max-width: 768px) {
     .grid {
-        margin-top: 0vh;
-        padding-top: 7.25vh;
+      margin-top: 0vh;
+      padding-top: 7.25vh;
     }
   }
 </style>
@@ -49,22 +48,21 @@
         <span class="right-side-paragraphs">
           <span class="project-initals">
             <p id="filterButton"
-               class="title_link active"
-               data-filter="all"
-            >
+              class="title_link active"
+              data-filter="all">
               All Projects [<?php echo ($page->children()->listed()->count()); ?>]
             </p>
-            
-            <?php 
+
+            <?php
             $tags = $page->children()->listed()->pluck('dataname', ',', true);
             foreach ($tags as $tag):
-                $totalDataNames = $page->children()->listed()->filterBy('dataname', $tag)->count();
+              $totalDataNames = $page->children()->listed()->filterBy('dataname', $tag)->count();
             ?>
-                <p id="filterButton" 
-                   class="title_link <?= $tag ?>" 
-                   data-filter="<?= $tag ?>">
-                    <?= $tag ?>  [<?= $totalDataNames ?>]
-                </p>
+              <p id="filterButton"
+                class="title_link <?= $tag ?>"
+                data-filter="<?= $tag ?>">
+                <?= $tag ?> [<?= $totalDataNames ?>]
+              </p>
             <?php endforeach ?>
           </span>
           <span>
@@ -74,66 +72,59 @@
           <?php endif ?>
           <span>
           </span>
-        </span> 
+        </span>
       </div>
-    </section> 
-    
+    </section>
+
     <section class="project-grid projects-grid">
       <ul class="grid project-grid">
         <?php foreach ($page->children()->listed() as $project): ?>
-        <li class="column"
-            data-name="<?= $project->dataname() ?>"
-        >
-          <a class="project-link" 
-             onclick="javascript:setTimeout(()=>{window.location = '<?= $project->url() ?>' },1000);"
-          >
+          <li class="column"
+            data-name="<?= $project->dataname() ?>">
+            <a class="project-link"
+              onclick="javascript:setTimeout(()=>{window.location = '<?= $project->url() ?>' },1000);">
               <?php if ($coverone = $project->coverone()->toFile()): ?>
                 <span class="img">
-                  <?php if($video = $project->video()->toFile()): ?>
+                  <?php if ($video = $project->video()->toFile()): ?>
                     <span class="image_video_wrapper single-img-12-8">
                       <video class="video"
-                             <?php if ($covertwo = $project->covertwo()->toFile()): ?>
-                             poster="<?= $covertwo->url() ?>"
-                             <?php endif ?>
-                             src="<?= $video->url() ?>"
-                             preload 
-                             autobuffer 
-                             muted 
-                             playsinline
-                             autoplay
-                             loop
-                      >
+                        <?php if ($covertwo = $project->covertwo()->toFile()): ?>
+                        poster="<?= $covertwo->url() ?>"
+                        <?php endif ?>
+                        src="<?= $video->url() ?>"
+                        preload
+                        autobuffer
+                        muted
+                        playsinline
+                        autoplay
+                        loop>
                       </video>
                       <img src="<?= $coverone->url() ?>"
-                           alt="<?= $coverone->alt()->esc() ?>"
-                           onmouseover="this.style.opacity = 0"
-                           onmouseout="this.style.opacity = 1"
-                           class="project_image_alt"
-                           id="<?= $coverone->parallax() ?>"
-                      >
+                        alt="<?= $coverone->alt()->esc() ?>"
+                        onmouseover="this.style.opacity = 0"
+                        onmouseout="this.style.opacity = 1"
+                        class="project_image_alt"
+                        id="<?= $coverone->parallax() ?>">
                     </span>
                   <?php elseif ($covertwo = $project->covertwo()->toFile()): ?>
                     <span class="image_video_wrapper single-img-12-8">
                       <img src="<?= $covertwo->url() ?>"
-                           alt="<?= $covertwo->alt()->esc() ?>"
-                           class="project_image_alt"
-                           id="<?= $covertwo->parallax() ?>"
-                      />
+                        alt="<?= $covertwo->alt()->esc() ?>"
+                        class="project_image_alt"
+                        id="<?= $covertwo->parallax() ?>" />
                       <img src="<?= $coverone->url() ?>"
-                           onmouseover="this.style.opacity = 0"
-                           onmouseout="this.style.opacity = 1"
-                           alt="<?= $coverone->alt()->esc() ?>"
-                           class="project_image_alt"
-                           id="<?= $coverone->parallax() ?>"
-                      />
+                        onmouseover="this.style.opacity = 0"
+                        onmouseout="this.style.opacity = 1"
+                        alt="<?= $coverone->alt()->esc() ?>"
+                        class="project_image_alt"
+                        id="<?= $coverone->parallax() ?>" />
                     </span>
                   <?php else: ?>
                     <span class="image_video_wrapper single-img-12-8">
                       <img src="<?= $coverone->url() ?>"
-                           alt="<?= $coverone->alt()->esc() ?>"
-                           class="project_image_alt"
-                           id="<?= $coverone->parallax() ?>"
-                      >
+                        alt="<?= $coverone->alt()->esc() ?>"
+                        class="project_image_alt"
+                        id="<?= $coverone->parallax() ?>">
                     </span>
                   <?php endif ?>
                 </span>
@@ -142,20 +133,21 @@
                 <p class="project-heading"><?= $project->title()->esc() ?></p>
                 <p class="subheading"><?= $project->subheadline()->esc() ?></p>
               </figcaption>
-          </a>
-        </li>
+            </a>
+          </li>
         <?php endforeach ?>
       </ul>
     </section>
 
     <section class="footer-block">
-     <?php snippet('footer-content') ?>
+      <?php snippet('footer-content') ?>
     </section>
+
   </div>
+
 </article>
 
 <script>
-
   let projects = document.querySelectorAll('.project-link');
   projects.forEach(project => {
     const subheadingCont = project.querySelector('figcaption.img-caption');
@@ -183,9 +175,9 @@
 
   const blackpageItems = document.querySelectorAll(".blackpage-nav-item");
   blackpageItems.forEach(blackpageItem => {
-    blackpageItem.addEventListener("click", function(){
+    blackpageItem.addEventListener("click", function() {
       loader.style.transform = "translateY(0%)";
-  
+
       const header = document.querySelector(".header");
       const html = document.documentElement;
       const body = document.querySelector("body");


### PR DESCRIPTION
These changes make the footer block stick to the bottom of the screen and get revealed when the bottom of the page is reached. This was achieved with a combination of position: sticky, bottom set to 0 and also the use of a negative z-index.

Some additional tweaks:
- The above change meant that all of the sections within `.scroll__container` needed to have a background set, otherwise the footer would show through. To do this I set that all sections inside `.scroll__container` which have a black background (and white on work pages). This also required me to wrap some of the about blocks in sections as required, as well as swap the use of to and bottom margins to padding instead to eliminate gaps in the backgrounds.
- I felt this scrolling effect required to have a line present at the bottom of the `.scroll__container` as it reveals the footer. I achieved this by adding a border bottom to the 2nd last child inside `.scroll__container`.

Sorry for the large diff, I have prettier installed which automatically cleaned up all the files I was in 😬